### PR TITLE
Add bootstrap script for local dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,3 +226,13 @@ NO WARRANTY EXPRESSED OR IMPLIED.**
 
 ![openpilot tests](https://github.com/commaai/openpilot/actions/workflows/selfdrive_tests.yaml/badge.svg)
 [![codecov](https://codecov.io/gh/commaai/openpilot/branch/master/graph/badge.svg)](https://codecov.io/gh/commaai/openpilot)
+
+Developer Environment Setup
+---------------------------
+To set up a local environment run:
+
+```bash
+bash bootstrap.sh
+source /workspace/activate_env.sh
+```
+

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -e
+
+START_TIME=$(date +%s)
+
+# Update and install system packages
+sudo apt-get update
+sudo apt-get install -y --no-install-recommends \
+  python3 python3-venv python3-dev python3-pip build-essential \
+  git curl ca-certificates ffmpeg \
+  libglib2.0-0 libgl1 libglfw3 libgles2-mesa-dev
+
+# Setup caches
+SCONS_CACHE=/workspace/scons_cache
+COMMA_CACHE=/workspace/comma_cache
+COMMA_DOWNLOAD_CACHE=/workspace/comma_download_cache
+mkdir -p "$SCONS_CACHE" "$COMMA_CACHE" "$COMMA_DOWNLOAD_CACHE"
+
+# Create python virtual environment
+VENV_DIR=/tmp/openpilot-env
+python3 -m venv "$VENV_DIR"
+source "$VENV_DIR/bin/activate"
+
+pip install --upgrade pip
+pip install numpy scipy opencv-python-headless pycapnp==2.0.0 tqdm psutil
+
+# Create activation script
+cat <<EOS > /workspace/activate_env.sh
+#!/usr/bin/env bash
+source /tmp/openpilot-env/bin/activate
+cd /workspace
+export SCONS_CACHE=$SCONS_CACHE
+export COMMA_CACHE=$COMMA_CACHE
+export COMMA_DOWNLOAD_CACHE=$COMMA_DOWNLOAD_CACHE
+EOS
+chmod +x /workspace/activate_env.sh
+
+END_TIME=$(date +%s)
+DURATION=$((END_TIME - START_TIME))
+
+echo "Bootstrap completed in ${DURATION}s"
+echo "Run: source /workspace/activate_env.sh"
+
+# activate for current session
+source /workspace/activate_env.sh
+


### PR DESCRIPTION
## Summary
- add `bootstrap.sh` for setting up dependencies and Python virtualenv
- create `/workspace/activate_env.sh` when running bootstrap
- document how to run the bootstrap script in README

## Testing
- `bash bootstrap.sh`


------
https://chatgpt.com/codex/tasks/task_e_684f23fdc18c832eae433398dd58cf48